### PR TITLE
Improved and fixed dependencies in makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ wheels/
 *.egg
 local/
 
+# makefile
+.local
+.timestamps
+
 # virtualenv
 .venv
 

--- a/Makefile
+++ b/Makefile
@@ -2,45 +2,48 @@ SHELL = /bin/bash
 
 .DEFAULT_GOAL := help
 
+SERVICE_NAME := service-qrcode
+
 CURRENT_DIR := $(shell pwd)
-INSTALL_DIR := $(CURRENT_DIR)/.venv
-PYTHON_LOCAL_DIR := $(CURRENT_DIR)/build/local
-PYTHON_FILES := $(shell find ./* -type f -name "*.py" -print)
+VENV := $(CURRENT_DIR)/.venv
+REQUIREMENTS = $(CURRENT_DIR)/requirements.txt
+DEV_REQUIREMENTS = $(CURRENT_DIR)/dev_requirements.txt
 TEST_REPORT_DIR := $(CURRENT_DIR)/tests/report
 TEST_REPORT_FILE := nose2-junit.xml
 
-#FIXME: put this variable in config file
+# Python local build directory
+PYTHON_LOCAL_DIR := $(CURRENT_DIR)/.local
+
+# venv targets timestamps
+VENV_TIMESTAMP = $(VENV)/.timestamp
+REQUIREMENTS_TIMESTAMP = $(VENV)/.requirements.timestamp
+DEV_REQUIREMENTS_TIMESTAMP = $(VENV)/.dev-requirements.timestamp
+
+# general targets timestamps
+TIMESTAMPS = .timestamps
+SYSTEM_PYTHON_TIMESTAMP = $(TIMESTAMPS)/.python-system.timestamp
+PYTHON_LOCAL_BUILD_TIMESTAMP = $(TIMESTAMPS)/.python-build.timestamp
+DOCKER_BUILD_TIMESTAMP = $(TIMESTAMPS)/.dockerbuild.timestamp
+
+# Find all python files that are not inside a hidden directory (directory starting with .)
+PYTHON_FILES := $(shell find ./* -type f -name "*.py" -print)
+
 PYTHON_VERSION := 3.7.4
-SYSTEM_PYTHON_CMD := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR})
+SYSTEM_PYTHON := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR})
 
 # default configuration
 HTTP_PORT ?= 5000
 
 # Commands
-PYTHON_CMD := $(INSTALL_DIR)/bin/python3
-PIP_CMD := $(INSTALL_DIR)/bin/pip3
-FLASK_CMD := $(INSTALL_DIR)/bin/flask
-YAPF_CMD := $(INSTALL_DIR)/bin/yapf
-NOSE_CMD := $(INSTALL_DIR)/bin/nose2
-PYLINT_CMD := $(INSTALL_DIR)/bin/pylint
+PYTHON := $(VENV)/bin/python3
+PIP := $(VENV)/bin/pip3
+FLASK := $(VENV)/bin/flask
+YAPF := $(VENV)/bin/yapf
+NOSE := $(VENV)/bin/nose2
+PYLINT := $(VENV)/bin/pylint
+
+
 all: help
-
-# This bit check define the build/python "target": if the system has an acceptable version of python, there will be no need to install python locally.
-
-ifneq ($(SYSTEM_PYTHON_CMD),)
-build/python:
-	@echo "Using system" $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1)
-	@echo $(shell $(SYSTEM_PYTHON_CMD) -c "print('OK')")
-	mkdir -p build
-	touch build/python
-else
-build/python: $(PYTHON_LOCAL_DIR)/bin/python3.7
-	@echo "Using local" $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1)
-	@echo $(shell $(SYSTEM_PYTHON_CMD) -c "print('OK')")
-
-SYSTEM_PYTHON_CMD := $(PYTHON_LOCAL_DIR)/bin/python3.7
-endif
-
 
 
 .PHONY: help
@@ -48,10 +51,13 @@ help:
 	@echo "Usage: make <target>"
 	@echo
 	@echo "Possible targets:"
-	@echo -e " \033[1mBUILD TARGETS\033[0m "
+	@echo -e " \033[1mSetup TARGETS\033[0m "
 	@echo "- setup              Create the python virtual environment"
-	@echo -e " \033[1mLINTING TOOLS TARGETS\033[0m "
-	@echo "- lint               Lint and format the python source code"
+	@echo "- dev                Create the python virtual environment with developper tools"
+	@echo -e " \033[1mFORMATING, LINTING AND TESTING TOOLS TARGETS\033[0m "
+	@echo "- format             Format the python source code"
+	@echo "- lint               Lint the python source code"
+	@echo "- format-lint        Format and lint the python source code"
 	@echo "- test               Run the tests"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
 	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 5000)"
@@ -63,72 +69,135 @@ help:
 	@echo "- clean              Clean genereated files"
 	@echo "- clean_venv         Clean python venv"
 
-# Build targets. Calling setup is all that is needed for the local files to be installed as needed. Bundesnetz may cause problem.
 
-python: build/python
-	@echo $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1) "installed"
+# Build targets. Calling setup is all that is needed for the local files to be installed as needed.
+
+.PHONY: dev
+dev: $(DEV_REQUIREMENTS_TIMESTAMP)
+
 
 .PHONY: setup
-setup: python .venv/build.timestamp
+setup: $(REQUIREMENTS_TIMESTAMP)
 
-
-$(PYTHON_LOCAL_DIR)/bin/python3.7:
-	@echo "Building a local python..."
-	mkdir -p $(PYTHON_LOCAL_DIR);
-	curl -z $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz -o $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz;
-	cd $(PYTHON_LOCAL_DIR) && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure --prefix=$(PYTHON_LOCAL_DIR)/ && make altinstall
-
-.venv/build.timestamp: build/python
-	$(SYSTEM_PYTHON_CMD) -m venv $(INSTALL_DIR) && $(PIP_CMD) install --upgrade pip setuptools
-	${PIP_CMD} install -r dev_requirements.txt
-	$(PIP_CMD) install -r requirements.txt
-	touch .venv/build.timestamp
 
 # linting target, calls upon yapf to make sure your code is easier to read and respects some conventions.
 
+.PHONY: format
+format: $(DEV_REQUIREMENTS_TIMESTAMP)
+	$(YAPF) -p -i --style .style.yapf $(PYTHON_FILES)
+
+
 .PHONY: lint
-lint: .venv/build.timestamp
-	$(YAPF_CMD) -p -i --style .style.yapf $(PYTHON_FILES)
-	$(PYLINT_CMD) $(PYTHON_FILES)
+lint: $(DEV_REQUIREMENTS_TIMESTAMP)
+	$(PYLINT) $(PYTHON_FILES)
+
+
+.PHONY: format-lint
+format-lint: format lint
+
+
+# Test target
 
 .PHONY: test
-test: .venv/build.timestamp
+test: $(REQUIREMENTS_TIMESTAMP)
 	mkdir -p $(TEST_REPORT_DIR)
-	$(NOSE_CMD) -c tests/unittest.cfg --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path $(TEST_REPORT_DIR)/$(TEST_REPORT_FILE) -s tests/
+	$(NOSE) -c tests/unittest.cfg --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path $(TEST_REPORT_DIR)/$(TEST_REPORT_FILE) -s tests/
+
 
 # Serve targets. Using these will run the application on your local machine. You can either serve with a wsgi front (like it would be within the container), or without.
+
 .PHONY: serve
-serve: .venv/build.timestamp
-	FLASK_APP=service_qrcode FLASK_DEBUG=1 $(FLASK_CMD) run --host=0.0.0.0 --port=$(HTTP_PORT)
+serve: $(REQUIREMENTS_TIMESTAMP)
+	FLASK_APP=$(subst -,_,$(SERVICE_NAME)) FLASK_DEBUG=1 $(FLASK) run --host=0.0.0.0 --port=$(HTTP_PORT)
+
 
 .PHONY: gunicornserve
-gunicornserve: .venv/build.timestamp
-	${PYTHON_CMD} wsgi.py
+gunicornserve: $(REQUIREMENTS_TIMESTAMP)
+	$(PYTHON) wsgi.py
+
 
 # Docker related functions.
 
 .PHONY: dockerbuild
-dockerbuild:
-	docker build -t swisstopo/service-qrcode:local .
+dockerbuild: $(DOCKER_BUILD_TIMESTAMP)
 
-export-http-port:
-	@export HTTP_PORT=$(HTTP_PORT)
 
 .PHONY: dockerrun
-dockerrun: export-http-port
-	docker-compose up -d;
+dockerrun: $(DOCKER_BUILD_TIMESTAMP)
+	export HTTP_PORT=$(HTTP_PORT); docker-compose up -d
 	sleep 10
 
+
 .PHONY: shutdown
-shutdown: export-http-port
-	docker-compose down
+shutdown:
+	export HTTP_PORT=$(HTTP_PORT); docker-compose down
 
-# Cleaning functions. clean_venv will only remove the virtual environment, while clean will also remove the local python installation.
-
-.PHONY: clean
-clean: clean_venv
-	rm -rf build;
 
 .PHONY: clean_venv
 clean_venv:
-	rm -rf ${INSTALL_DIR};
+	rm -rf $(VENV)
+
+
+.PHONY: clean
+clean: clean_venv
+	@# clean python cache files
+	find . -name __pycache__ -type d -print0 | xargs -I {} -0 rm -rf "{}"
+	rm -rf $(PYTHON_LOCAL_DIR)
+	rm -rf $(TEST_REPORT_DIR)
+	rm -rf $(TIMESTAMPS)
+
+
+# Actual builds targets with dependencies
+
+$(TIMESTAMPS):
+	mkdir -p $(TIMESTAMPS)
+
+$(VENV_TIMESTAMP): $(SYSTEM_PYTHON_TIMESTAMP)
+	test -d $(VENV) || $(SYSTEM_PYTHON) -m venv $(VENV) && $(PIP) install --upgrade pip setuptools
+	@touch $(VENV_TIMESTAMP)
+
+
+$(REQUIREMENTS_TIMESTAMP): $(VENV_TIMESTAMP) $(REQUIREMENTS)
+	$(PIP) install -U pip wheel; \
+	$(PIP) install -r $(REQUIREMENTS);
+	@touch $(REQUIREMENTS_TIMESTAMP)
+
+
+$(DEV_REQUIREMENTS_TIMESTAMP): $(REQUIREMENTS_TIMESTAMP) $(DEV_REQUIREMENTS)
+	$(PIP) install -r $(DEV_REQUIREMENTS)
+	@touch $(DEV_REQUIREMENTS_TIMESTAMP)
+
+
+$(DOCKER_BUILD_TIMESTAMP): $(TIMESTAMPS) $(PYTHON_FILES) $(CURRENT_DIR)/Dockerfile
+	docker build -t swisstopo/$(SERVICE_NAME):local .
+	touch $(DOCKER_BUILD_TIMESTAMP)
+
+
+# Python local build target
+
+ifneq ($(SYSTEM_PYTHON),)
+
+# A system python matching version has been found use it
+$(SYSTEM_PYTHON_TIMESTAMP): $(TIMESTAMPS)
+	@echo "Using system" $(shell $(SYSTEM_PYTHON) --version 2>&1)
+	touch $(SYSTEM_PYTHON_TIMESTAMP)
+
+
+else
+
+# No python version found, build it localy
+$(SYSTEM_PYTHON_TIMESTAMP): $(TIMESTAMPS) $(PYTHON_LOCAL_BUILD_TIMESTAMP)
+	@echo "Using local" $(shell $(SYSTEM_PYTHON) --version 2>&1)
+	touch $(SYSTEM_PYTHON_TIMESTAMP)
+
+
+$(PYTHON_LOCAL_BUILD_TIMESTAMP): $(TIMESTAMPS)
+	@echo "Building a local python..."
+	mkdir -p $(PYTHON_LOCAL_DIR);
+	curl -z $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz -o $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz;
+	cd $(PYTHON_LOCAL_DIR) && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure --prefix=$(PYTHON_LOCAL_DIR)/ && make altinstall
+	touch $(PYTHON_LOCAL_BUILD_TIMESTAMP)
+
+SYSTEM_PYTHON := $(PYTHON_LOCAL_DIR)/python
+
+endif

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -37,7 +37,7 @@ phases:
       - docker build -t ${IMAGE_BASE_NAME}:${IMAGE_TAG} .
   post_build:
     commands:
-      - .venv/bin/pylint $(find ./* -type f -name "*.py" -print)
+      - make lint
       - mkdir -p ${TEST_REPORT_DIR}
       - export TEST_REPORT_DIR=${TEST_REPORT_DIR}
       - export TEST_REPORT_FILE=${TEST_REPORT_FILE}


### PR DESCRIPTION

Makefile dependencies where not correct. For example if a pip requirements
file were modified the requirements need to be manually re-installed.
There was also an using with the lint target when a local python build
was done, because the local python build was inside a normal directory,
its content was passed to pylint which they failed. Also the local build
for another python version of 3.7 would have not worked due to hard
coded python bin to `python3.7`.

Now all dependencies have been corrected, which means that in between
two call of `make serve` if the requirements.txt has been modified, the
target `make setup` is automatically called.

The python local build is now done within a hidden directory (.local)
which is then not passed to pylint nor to yapf.