### PR TITLE
BGDIINF_SB-1463: Fixed issue with bump version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,3 @@ jobs:
           WITH_V: true
           RELEASE_BRANCHES: master
           TAG_CONTEXT: repo
-          INITIAL_VERSION: 0.1.0


### PR DESCRIPTION
The bump version failed because it somehow tried to create a version taking the INITIAL_VERSION as basis instead of the last existing versions. INITIAL_VERSION has been added to avoid to start to 0.0.0 but it didn't worked anyway.