### PR TITLE
Fixed docker crash due to wrong version.py file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ LABEL version=$VERSION
 LABEL author=$AUTHOR
 
 # Overwrite the version.py from source with the actual version
-RUN echo "APP_VERSION = '$VERSION'" > /app/version.py
+RUN echo "APP_VERSION = '$VERSION'" > /app/app/version.py
 
 USER geoadmin
 


### PR DESCRIPTION
In the docker file the app/version.py was not correctly overwritten
leaving the one with the git stuff in it. This was due to a wrong path
in the docker file.

Hopefully this time everything is all good :-/