### PR TITLE
Don't add CORS to /checker

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,6 +47,10 @@ def validate_origin():
 # Add CORS Headers to all request
 @app.after_request
 def add_cors_header(response):
+    # Do not add CORS header to internal /checker endpoint.
+    if request.endpoint == 'checker':
+        return response
+
     if (
         'Origin' in request.headers and
         re.match(ALLOWED_DOMAINS_PATTERN, request.headers['Origin'])
@@ -60,7 +64,7 @@ def add_cors_header(response):
 @app.after_request
 def add_cache_control_header(response):
     # For /checker route we let the frontend proxy decide how to cache it.
-    if request.method == 'GET' and request.path != url_for('check'):
+    if request.method == 'GET' and request.endpoint != 'checker':
         if response.status_code >= 400:
             response.headers.set('Cache-Control', CACHE_CONTROL_4XX)
         else:

--- a/app/routes.py
+++ b/app/routes.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @app.route('/checker', methods=['GET'])
-def check():
+def checker():
     return make_response(jsonify({'success': True, 'message': 'OK', 'version': APP_VERSION}))
 
 

--- a/tests/unit_tests/test_qrcode.py
+++ b/tests/unit_tests/test_qrcode.py
@@ -45,7 +45,7 @@ class QrCodeTests(unittest.TestCase):
         self.assertEqual(response.headers['Access-Control-Allow-Headers'], '*')
 
     def test_checker(self):
-        response = self.app.get(url_for('check'), headers=self.valid_origin_header)
+        response = self.app.get(url_for('checker'), headers=self.valid_origin_header)
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('Cache-Control', response.headers)
         self.assertEqual(response.content_type, "application/json")


### PR DESCRIPTION
This is an internal endpoint used by k8s and don't require CORS