### PR TITLE
BGDIINF_SB-2051: Standardising referrer/origin check

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,11 +36,18 @@ def log_route():
 # Reject request from non allowed origins
 @app.before_request
 def validate_origin():
-    if 'Origin' not in request.headers:
-        logger.error('Origin header is not set')
+    origin = request.headers.get('Origin')
+    referer = request.headers.get('Referer')
+    if origin is None and referer is None:
+        logger.error('Origin and/or Referer header(s) is/are not set')
         abort(403, 'Not allowed')
-    if not re.match(ALLOWED_DOMAINS_PATTERN, request.headers['Origin']):
-        logger.error('Origin=%s is not allowed', request.headers['Origin'])
+    header = 'Origin'
+    value = origin
+    if origin is None:
+        header = 'Referer'
+        value = referer
+    if not re.match(ALLOWED_DOMAINS_PATTERN, value):
+        logger.error('%s=%s is not allowed', header, value)
         abort(403, 'Not allowed')
 
 

--- a/tests/unit_tests/test_qrcode.py
+++ b/tests/unit_tests/test_qrcode.py
@@ -100,6 +100,20 @@ class QrCodeTests(unittest.TestCase):
             }
         )
 
+    def test_referer_check(self):
+        response = self.app.get(url_for('generate_get'), headers={'Referer': 'not allowed'})
+        self.assertEqual(
+            response.status_code, 403, msg="Non allowed Referer did not returned an HTTP 403"
+        )
+        response = self.app.get(
+            url_for('generate_get'),
+            query_string={'url': 'https://some_random_domain/test'},
+            headers={'Referer': 'some_random_domain'}
+        )
+        self.assertEqual(
+            response.status_code, 200, msg="Allowed Referer did not returned an HTTP 200"
+        )
+
     def test_generate_domain_restriction(self):
         response = self.app.get(
             url_for('generate_get'),


### PR DESCRIPTION
Browser is sending Origin/Referrer headers, while some backend service (for example service-print) are only sending Referrer header (if any)



See https://jira.swisstopo.ch/browse/BGDIINF_SB-2051