### PR TITLE
BGDIINF_SB-3115: Fixed IOS 16.6 403 Forbidden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,7 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo -e " \033[1mSetup TARGETS\033[0m "
-	@echo "- setup              Create the python virtual environment and activate it"
-	@echo "- dev                Create the python virtual environment with developper tools and activate it"
+	@echo "- setup              Create the python virtual environment with developper tools and activate it"
 	@echo "- ci                 Create the python virtual environment and install requirements based on the Pipfile.lock"
 	@echo -e " \033[1mFORMATING, LINTING AND TESTING TOOLS TARGETS\033[0m "
 	@echo "- format             Format the python source code"
@@ -89,15 +88,9 @@ help:
 
 # Build targets. Calling setup is all that is needed for the local files to be installed as needed.
 
-.PHONY: dev
-dev: $(REQUIREMENTS)
-	pipenv install --dev
-	pipenv shell
-
-
 .PHONY: setup
 setup: $(REQUIREMENTS)
-	pipenv install
+	pipenv install --dev
 	pipenv shell
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,22 +49,33 @@ def validate_origin():
     origin = request.headers.get('Origin', None)
     referrer = request.headers.get('Referer', None)
 
+    logger.debug(
+        "Validate origin: sec_fetch_site=%s, origin=%s, referrer=%s",
+        sec_fetch_site,
+        origin,
+        referrer
+    )
+
     if origin is not None:
         if is_domain_allowed(origin):
             return
         logger.error('Origin=%s does not match %s', origin, ALLOWED_DOMAINS_PATTERN)
         abort(403, 'Permission denied')
 
-    if sec_fetch_site is not None:
-        if sec_fetch_site in ['same-origin', 'same-site']:
-            return
-        logger.error('Sec-Fetch-Site=%s is not allowed', sec_fetch_site)
-        abort(403, 'Permission denied')
-
+    # BGDIINF_SB-3115: Apparently IOS 16 has a bug and set Sec-Fetch-Site=cross-site even if the
+    # request is originated (same origin and/or referrer) from the same site ! Therefore to avoid
+    # issue on IOS we first checks the referrer before checking Sec-Fetch-Site even if this not
+    # correct.
     if referrer is not None:
         if is_domain_allowed(referrer):
             return
         logger.error('Referer=%s does not match %s', referrer, ALLOWED_DOMAINS_PATTERN)
+        abort(403, 'Permission denied')
+
+    if sec_fetch_site is not None:
+        if sec_fetch_site in ['same-origin', 'same-site']:
+            return
+        logger.error('Sec-Fetch-Site=%s is not allowed', sec_fetch_site)
         abort(403, 'Permission denied')
 
     logger.error('Referer and/or Origin and/or Sec-Fetch-Site headers not set')


### PR DESCRIPTION
Apparently IOS 16.6.1 (some other previous version might also be concerd) has
a bug and set Sec-Fetch-Site=cross-site even if the request is originated
(same origin and/or referrer) from the same site ! Therefore to avoid issue on
IOS we first checks the referrer before checking Sec-Fetch-Site even if this not
correct/safe (Referrer header is easily hacked, while Sec-Fetch-Site is always
overwritten by the browser).

Also clean up makefile, differentiating between `make dev` and `make setup`
doesn't make sense as we never install locally without the dev dependencies and
nowadays most of our services only have `make setup` with dev dependencies.